### PR TITLE
avoid fights with CSP

### DIFF
--- a/rollup-plugins/wat2wasm.js
+++ b/rollup-plugins/wat2wasm.js
@@ -31,9 +31,7 @@ export default function() {
       }
       const [, flags, path] = id.split(":", 3);
       const module = await compileWat(path, [flags]);
-      return `export default "data:application/wasm;base64,${module.toString(
-        "base64"
-      )}";`;
+      return `export default "${module.toString("base64")}";`;
     }
   };
 }

--- a/src/detectors/exceptions/module.wat
+++ b/src/detectors/exceptions/module.wat
@@ -1,7 +1,9 @@
 (module
-  (func 
+  (func
     (try
-      (catch)
+      (catch
+        (drop)
+      )
     )
   )
 )

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -11,12 +11,25 @@
  * limitations under the License.
  */
 
+function decodeBase64(b64) {
+  try {
+    return Buffer.from(b64, "base64");
+  } catch {
+    const byteString = atob(data);
+    const buffer = new Uint8Array(byteString.length);
+    for (let i = 0; i < byteString.length; i += 1) {
+      buffer[i] = byteString.charCodeAt(i);
+    }
+    return buffer;
+  }
+}
+
 // This function only exists because `WebAssembly.compile` will
 // be called quite often and by having our own function terser can give it
 // a one-letter name.
-export async function testCompile(path) {
+export async function testCompile(data) {
   try {
-    await WebAssembly.compile(await fetch(path).then(r => r.arrayBuffer()));
+    await WebAssembly.compile(decodeBase64(data));
     return true;
   } catch (e) {
     return false;


### PR DESCRIPTION
`fetch(data url)` can be prohibited by CSP, so this avoids that. This also means this module works in node now!

the `drop` in exception detection was needed for it to compile on the latest wat2wasm, which types a `catch` block as [exnref] -> []