### PR TITLE
Use WebAssembly.validate for feature detection

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -15,10 +15,5 @@
 // be called quite often and by having our own function terser can give it
 // a one-letter name.
 export async function testCompile(path) {
-  try {
-    await WebAssembly.compile(await fetch(path).then(r => r.arrayBuffer()));
-    return true;
-  } catch (e) {
-    return false;
-  }
+  return fetch(path).then(r => r.arrayBuffer()).then(WebAssembly.validate);
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -14,6 +14,6 @@
 // This function only exists because `WebAssembly.compile` will
 // be called quite often and by having our own function terser can give it
 // a one-letter name.
-export async function testCompile(path) {
+export function testCompile(path) {
   return fetch(path).then(r => r.arrayBuffer()).then(WebAssembly.validate);
 }


### PR DESCRIPTION
This should be faster, since it avoids actual module compilation, and I believe will still work the same for unsupported features.