### PR TITLE
Simplify SAB test

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A small library to detect which features of WebAssembly are supported.
 - ✅ Runs in Node
 - ✅ Provided as an ES6 module, CommonJS and UMD module.
 - ✅ CSP compatible
-- ✅ Only ~550B gzipped
+- ✅ Only ~520B gzipped
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A small library to detect which features of WebAssembly are supported.
 - ✅ Runs in Node
 - ✅ Provided as an ES6 module, CommonJS and UMD module.
 - ✅ CSP compatible
-- ✅ Only ~550B
+- ✅ Only ~550B gzipped
 
 ## Installation
 

--- a/README.md.ejs
+++ b/README.md.ejs
@@ -6,7 +6,7 @@ A small library to detect which features of WebAssembly are supported.
 - ✅ Runs in Node
 - ✅ Provided as an ES6 module, CommonJS and UMD module.
 - ✅ CSP compatible
-- ✅ Only ~550B
+- ✅ Only ~<%= gzippedSize %>B gzipped
 
 ## Installation
 
@@ -57,7 +57,7 @@ The _other_ reason is that you _should_ be using `WebAssembly.compile`, `WebAsse
 
 ## Contributing
 
-If you want to contribute a new feature test, all you need to do is create a new folder in `src/detectors` and it will be automatically picked up. The folder must contain a `module.wat` file, which will be compiled using [`wat2wasm`][wat2wasm]. 
+If you want to contribute a new feature test, all you need to do is create a new folder in `src/detectors` and it will be automatically picked up. The folder must contain a `module.wat` file, which will be compiled using [`wat2wasm`][wat2wasm].
 
 ```wat
 ;; Name: <Name of the feature for the README>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:library": "rollup -c",
     "build:readme": "node --experimental-modules ./render-readme.mjs",
     "build": "npm run build:library && npm run build:readme && npm run fmt",
-    "fmt": "prettier --write './{,{src,rollup-plugins}/**/}*.{mjs,js,md}'"
+    "fmt": "prettier --write ./{,{src,rollup-plugins}/**/}*.{mjs,js,md}"
   },
   "repository": "GoogleChromeLabs/wasm-feature-detect",
   "keywords": [],

--- a/render-readme.mjs
+++ b/render-readme.mjs
@@ -13,6 +13,7 @@
 
 import ejs from "ejs";
 import { promises as fsp } from "fs";
+import { gzipSync } from "zlib";
 
 import { camelCaseify } from "./rollup-plugins/helpers.mjs";
 
@@ -29,7 +30,12 @@ async function run() {
       return { name, proposal, func: camelCaseify(detector) };
     })
   );
-  const readme = await ejs.renderFile("./README.md.ejs", { detectors });
+  const lib = await fsp.readFile("./dist/esm/index.js");
+  const gzippedLib = gzipSync(lib, { level: 9 });
+  const readme = await ejs.renderFile("./README.md.ejs", {
+    gzippedSize: Math.round(gzippedLib.length / 10) * 10,
+    detectors
+  });
   await fsp.writeFile("./README.md", readme);
 }
 run().catch(err => console.error(err));

--- a/src/detectors/threads/index.js
+++ b/src/detectors/threads/index.js
@@ -15,13 +15,9 @@ export default async function() {
   try {
     // Test for transferability of SABs (needed for Firefox)
     // https://groups.google.com/forum/#!msg/mozilla.dev.platform/IHkBZlHETpA/dwsMNchWEQAJ
-    await new Promise(resolve => {
-      const { port1, port2 } = new MessageChannel();
-      port2.onmessage = resolve;
-      port1.postMessage(new SharedArrayBuffer(1));
-    });
+    new MessageChannel().port1.postMessage(new SharedArrayBuffer(1));
     return true;
-  } catch (e) {
+  } catch {
     return false;
   }
 }


### PR DESCRIPTION

It doesn't have a chance to throw asynchronously, so don't wait for resolve either.

We still keep the function async for backward- and future-compatibility though.