### PR TITLE
Added tests and improved bundle size

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A small library to detect which features of WebAssembly are supported.
 - ✅ Runs in Node
 - ✅ Provided as an ES6 module, CommonJS and UMD module.
 - ✅ CSP compatible
-- ✅ Only ~520B gzipped
+- ✅ Only ~501B gzipped
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A small library to detect which features of WebAssembly are supported.
 - ✅ Runs in Node
 - ✅ Provided as an ES6 module, CommonJS and UMD module.
 - ✅ CSP compatible
-- ✅ Only ~501B gzipped
+- ✅ Only ~504B gzipped
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "build": "npm run build:library && npm run build:readme && npm run fmt",
     "build:website": "npm run build && node genwebsite.js",
     "build:website:netlify": "./build.sh",
-    "fmt": "prettier --write ./{,{src,rollup-plugins}/**/}*.{mjs,js,md}"
+    "fmt": "prettier --write ./{,{src,rollup-plugins}/**/}*.{mjs,js,md}",
+    "fmt_test": "test $(prettier -l ./{,{src,rollup-plugins}/**/}*.{mjs,js,md} | wc -l) -eq 0",
+    "test": "npm run fmt_test && npm run build && node --no-warnings test/index.js"
   },
   "repository": "GoogleChromeLabs/wasm-feature-detect",
   "keywords": [],

--- a/rollup-plugins/index-generator.js
+++ b/rollup-plugins/index-generator.js
@@ -51,11 +51,11 @@ export default function({ indexPath, pluginFolder }) {
             const importName = `${pluginName}_internal`;
             return `
             import { default as ${importName} } from "./${pluginFolder}/${plugin}/index.js";
-            export const ${pluginName} = ${importName}.bind(null, ${module}, validate);
+            export const ${pluginName} = ${importName}.bind(null, new Uint8Array(${module}), validate);
             `;
           }
           return `
-          export const ${pluginName} = validate.bind(null, ${module});
+          export const ${pluginName} = validate.bind(null, new Uint8Array(${module}));
           `;
         })
       );

--- a/rollup-plugins/index-generator.js
+++ b/rollup-plugins/index-generator.js
@@ -46,20 +46,16 @@ export default function({ indexPath, pluginFolder }) {
               flags
             ))
           ]);
+          const pluginName = camelCaseify(plugin);
           if (await fileExists(`./src/${pluginFolder}/${plugin}/index.js`)) {
+            const importName = `${pluginName}_internal`;
             return `
-            import { default as ${camelCaseify(
-              plugin
-            )}_internal } from "./${pluginFolder}/${plugin}/index.js";
-            export async function ${camelCaseify(plugin)}() {
-              return (await Promise.all([validate(${module}), ${camelCaseify(
-              plugin
-            )}_internal()])).every(x => x);
-            }
+            import { default as ${importName} } from "./${pluginFolder}/${plugin}/index.js";
+            export const ${pluginName} = ${importName}.bind(null, ${module}, validate);
             `;
           }
           return `
-          export const ${camelCaseify(plugin)} = validate.bind(null, ${module});
+          export const ${pluginName} = validate.bind(null, ${module});
           `;
         })
       );

--- a/src/detectors/threads/index.js
+++ b/src/detectors/threads/index.js
@@ -11,7 +11,8 @@
  * limitations under the License.
  */
 
-export default async function() {
+export default async function(module, validate) {
+  if (!(await validate(module))) return false;
   try {
     // Test for transferability of SABs (needed for Firefox)
     // https://groups.google.com/forum/#!msg/mozilla.dev.platform/IHkBZlHETpA/dwsMNchWEQAJ

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -15,5 +15,5 @@
 // be called quite often and by having our own function terser can give it
 // a one-letter name.
 export async function validate(module) {
-  return WebAssembly.validate(new Uint8Array(module));
+  return WebAssembly.validate(module);
 }

--- a/test/index.js
+++ b/test/index.js
@@ -24,22 +24,25 @@ const isBoolean = function (value) {
   return typeof value === 'boolean';
 }
 
-const checkFeature = function (featureName) {
+const checkFeature = async function (featureName) {
   const feature = features[featureName];
   assert(feature, `The feature ${featureName} doesn't exist`);
-  feature().then(function(result) {
-    console.log(`The feature ${featureName} returned: ${result}`);
-    assert(isBoolean(result), `The feature ${featureName} returned: ${result}`);
-  })
+  const result = await feature();
+  console.log(`The feature ${featureName} returned: ${result}`);
+  assert(isBoolean(result), `The feature ${featureName} returned: ${result}`);
 }
 
-checkFeature("bulkMemory");
-checkFeature("exceptions");
-checkFeature("multiValue");
-checkFeature("mutableGlobals");
-checkFeature("referenceTypes");
-checkFeature("saturatedFloatToInt");
-checkFeature("signExtensions");
-checkFeature("simd");
-checkFeature("tailCall");
-checkFeature("threads");
+async function run() {
+  await checkFeature("bulkMemory");
+  await checkFeature("exceptions");
+  await checkFeature("multiValue");
+  await checkFeature("mutableGlobals");
+  await checkFeature("referenceTypes");
+  await checkFeature("saturatedFloatToInt");
+  await checkFeature("signExtensions");
+  await checkFeature("simd");
+  await checkFeature("tailCall");
+  await checkFeature("threads");
+}
+
+run();

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const assert = require('assert');
+
+process.on("unhandledRejection", err => {
+  throw err;
+});
+
+// We try to import the generated module
+const features = require(__dirname+'/../dist/cjs');
+
+const isBoolean = function (value) {
+  return value === true || value === false;
+}
+
+const checkFeature = function (featureName) {
+  const feature = features[featureName];
+  assert(feature, `The feature ${featureName} doesn't exist`);
+  feature().then(function(result) {
+    console.log(`The feature ${featureName} returned: ${result}`);
+    assert(isBoolean(result), `The feature ${featureName} returned: ${result}`);
+  })
+}
+
+checkFeature("bulkMemory");
+checkFeature("exceptions");
+checkFeature("multiValue");
+checkFeature("mutableGlobals");
+checkFeature("referenceTypes");
+checkFeature("saturatedFloatToInt");
+checkFeature("signExtensions");
+checkFeature("simd");
+checkFeature("tailCall");
+checkFeature("threads");

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,7 @@ process.on("unhandledRejection", err => {
 const features = require(__dirname+'/../dist/cjs');
 
 const isBoolean = function (value) {
-  return value === true || value === false;
+  return typeof value === 'boolean';
 }
 
 const checkFeature = function (featureName) {


### PR DESCRIPTION
This PR does:
* Decrease bundle size by ~3% (from 520 bytes to 504 gzipped)
* Add tests (you can test with `npm run test`)

## Design rationale

This PR moves the validation into the custom detector module (in case it exists).
There are two ways to do that in an efficient manner:

```js
// First option
export const  simd = simd_internal.bind(null, validate(bytes));

// Second option
export const  simd = simd_internal.bind(null, bytes, validate);
```

I went with the Second option because it enables richer kind of detectors with smaller bundle sizes.
This is useful, for example, when the detector not only validate but also instantiate the bytes and test its exported functions (see #8).