### PR TITLE
Shave 4 bytes off gzip

### DIFF
--- a/src/detectors/big-int/index.js
+++ b/src/detectors/big-int/index.js
@@ -13,7 +13,7 @@
 
 export default async function(bytes) {
   try {
-    const n = BigInt(0);
+    const n = 0n;
     const instance = await WebAssembly.instantiate(bytes);
     return instance.instance.exports.b(n) === n;
   } catch {


### PR DESCRIPTION
Before
```
./src/index.js → dist/esm...
gzipped size: 576
raw size: 1709
created dist/esm in 313ms

./src/index.js → dist/cjs...
gzipped size: 627
raw size: 1830
created dist/cjs in 376ms

./src/index.js → dist/umd...
gzipped size: 718
raw size: 1947
created dist/umd in 436ms
```

After
```
./src/index.js → dist/esm...
gzipped size: 572
raw size: 1702
created dist/esm in 351ms

./src/index.js → dist/cjs...
gzipped size: 622
raw size: 1823
created dist/cjs in 293ms

./src/index.js → dist/umd...
gzipped size: 714
raw size: 1940
created dist/umd in 324ms
```