### PR TITLE
Fix size-printer

### DIFF
--- a/rollup-plugins/size-printer.js
+++ b/rollup-plugins/size-printer.js
@@ -3,7 +3,7 @@ import { gzipSync } from "zlib";
 export default function sizePrinter() {
   return {
     renderChunk(rawSource, chunk, outputOptions) {
-      const buffer = Buffer.from(rawSource);
+      const buffer = Buffer.from(rawSource + "\n");
       const gzipped = gzipSync(buffer, { level: 9 });
       console.log("gzipped size:", gzipped.length);
       console.log("raw size:", buffer.length);


### PR DESCRIPTION

Looks like Rollup outputs file with a trailing newline, but renderChunk gets passed a string without one, so sizes printed in console and rounded number in README often got out of sync.

This fixes that by adding a newline before gzipping.