### PR TITLE
Various size optimisations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A small library to detect which features of WebAssembly are supported.
 - ✅ Runs in Node
 - ✅ Provided as an ES6 module, CommonJS and UMD module.
 - ✅ CSP compatible
-- ✅ Only ~550B gzipped
+- ✅ Only ~520B gzipped
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A small library to detect which features of WebAssembly are supported.
 - ✅ Runs in Node
 - ✅ Provided as an ES6 module, CommonJS and UMD module.
 - ✅ CSP compatible
-- ✅ Only ~560B gzipped
+- ✅ Only ~550B gzipped
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A small library to detect which features of WebAssembly are supported.
 - ✅ Runs in Node
 - ✅ Provided as an ES6 module, CommonJS and UMD module.
 - ✅ CSP compatible
-- ✅ Only ~520B gzipped
+- ✅ Only ~510B gzipped
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -170,6 +170,15 @@
         "uc.micro": "^1.0.1"
       }
     },
+    "magic-string": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.4.tgz",
+      "integrity": "sha512-oycWO9nEVAP2RVPbIoDoA4Y7LFIJ3xRYov93gAyJhZkET1tNuB0u7uWkZS2LpBWTJUWnmau/To8ECWRC+jKNfw==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
     "markdown-it": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
@@ -255,6 +264,12 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "sourcemap-codec": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.6.tgz",
+      "integrity": "sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg==",
+      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "ejs": "^2.7.1",
+    "magic-string": "^0.25.4",
     "markdown-it": "^10.0.0",
     "prettier": "^1.18.2",
     "rollup": "^1.20.3",

--- a/rollup-plugins/export-in-place.js
+++ b/rollup-plugins/export-in-place.js
@@ -33,37 +33,69 @@ export default function() {
     name: "export-in-place",
 
     renderChunk(code) {
-      const ast = this.parse(code);
-      // Assert for the AST shape.
-      // 1) We should have only two declarations at top level.
-      assert.strictEqual(ast.body.length, 2);
-      const [varDecl, exportDecl] = ast.body;
-      // 2) First is a variable declaration (for `const ...`)
-      assert.strictEqual(varDecl.type, "VariableDeclaration");
-      // 3) Second is a local export list (`export { ... }`).
-      assert.strictEqual(exportDecl.type, "ExportNamedDeclaration");
-      assert.strictEqual(exportDecl.declaration, null);
-      assert.strictEqual(exportDecl.source, null);
-      // 4) Their counts must match.
-      assert.strictEqual(
-        varDecl.declarations.length,
-        exportDecl.specifiers.length
-      );
-      // Now, perform actual transformation - inline exported name back
-      // into each variable declarator.
-      const output = new MagicString(code);
-      const exportMap = new Map(
-        exportDecl.specifiers.map(spec => [spec.local.name, spec.exported.name])
-      );
-      for (const { id } of varDecl.declarations) {
-        const exportedName = exportMap.get(id.name);
-        // Make sure we're exporting only declared vars.
-        assert(exportedName);
-        exportMap.delete(id.name);
-        output.overwrite(id.start, id.end, exportedName);
+      try {
+        const ast = this.parse(code);
+        // Assert for the AST shape.
+        // 1) We should have only two declarations at top level.
+        assert.strictEqual(
+          ast.body.length,
+          2,
+          "Bundle should have only two items at the top level."
+        );
+        const [varDecl, exportDecl] = ast.body;
+        // 2) First is a variable declaration (for `const ...`).
+        assert.strictEqual(
+          varDecl.type,
+          "VariableDeclaration",
+          "First top-level item should be a variable declaration."
+        );
+        // 3) Second is a local export list (`export { ... }`).
+        assert.strictEqual(
+          exportDecl.type,
+          "ExportNamedDeclaration",
+          "Second top-level item should be an export declaration."
+        );
+        assert.strictEqual(
+          exportDecl.declaration,
+          null,
+          "Export declaration should contain a list of items."
+        );
+        assert.strictEqual(
+          exportDecl.source,
+          null,
+          "Export declaration should export local items."
+        );
+        // 4) Their counts must match.
+        assert.strictEqual(
+          varDecl.declarations.length,
+          exportDecl.specifiers.length,
+          "List of exports should contain as many items as there are variables."
+        );
+        // Now, perform actual transformation - inline exported name back
+        // into each variable declarator.
+        const output = new MagicString(code);
+        const exportMap = new Map(
+          exportDecl.specifiers.map(spec => [
+            spec.local.name,
+            spec.exported.name
+          ])
+        );
+        for (const { id } of varDecl.declarations) {
+          const exportedName = exportMap.get(id.name);
+          // Make sure we're exporting only declared vars.
+          assert(
+            exportedName,
+            `Export declaration for ${id.name} does not match a local variable.`
+          );
+          exportMap.delete(id.name);
+          output.overwrite(id.start, id.end, exportedName);
+        }
+        // Finally, prepend `export ` right before `const ...` and return it.
+        return `export ${output.slice(varDecl.start, varDecl.end)}`;
+      } catch (e) {
+        console.warn("Could not inline exports:", e);
+        return code;
       }
-      // Finally, prepend `export ` right before `const ...` and return it.
-      return `export ${output.slice(varDecl.start, varDecl.end)}`;
     }
   };
 }

--- a/rollup-plugins/export-in-place.js
+++ b/rollup-plugins/export-in-place.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This plugin is a workaround for a suboptimal format of Rollup
+// exports in ES module mode, where it produces code like:
+//
+// const A = 1, B = 2, ...;
+// export { A, B, ... };
+//
+// But for optimal size we can inline exports back as:
+//
+// export const A = 1, B = 2, ...;
+//
+// For now this plugin expects this specific form of exports
+// and isn't meant for general use, but still provides helpful size
+// optimisation for this project (~7% gzipped).
+
+import MagicString from "magic-string";
+import assert from "assert";
+
+export default function() {
+  return {
+    name: "export-in-place",
+
+    renderChunk(code) {
+      const ast = this.parse(code);
+      // Assert for the AST shape.
+      // 1) We should have only two declarations at top level.
+      assert.strictEqual(ast.body.length, 2);
+      const [varDecl, exportDecl] = ast.body;
+      // 2) First is a variable declaration (for `const ...`)
+      assert.strictEqual(varDecl.type, "VariableDeclaration");
+      // 3) Second is a local export list (`export { ... }`).
+      assert.strictEqual(exportDecl.type, "ExportNamedDeclaration");
+      assert.strictEqual(exportDecl.declaration, null);
+      assert.strictEqual(exportDecl.source, null);
+      // 4) Their counts must match.
+      assert.strictEqual(
+        varDecl.declarations.length,
+        exportDecl.specifiers.length
+      );
+      // Now, perform actual transformation - inline exported name back
+      // into each variable declarator.
+      const output = new MagicString(code);
+      const exportMap = new Map(
+        exportDecl.specifiers.map(spec => [spec.local.name, spec.exported.name])
+      );
+      for (const { id } of varDecl.declarations) {
+        const exportedName = exportMap.get(id.name);
+        // Make sure we're exporting only declared vars.
+        assert(exportedName);
+        exportMap.delete(id.name);
+        output.overwrite(id.start, id.end, exportedName);
+      }
+      // Finally, prepend `export ` right before `const ...` and return it.
+      return `export ${output.slice(varDecl.start, varDecl.end)}`;
+    }
+  };
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,6 +15,7 @@ import { terser } from "rollup-plugin-terser";
 
 import indexGenerator from "./rollup-plugins/index-generator.js";
 import sizePrinter from "./rollup-plugins/size-printer.js";
+import exportInPlace from "./rollup-plugins/export-in-place.js";
 
 export default ["esm", "cjs", "umd"].map(format => ({
   input: "./src/index.js",
@@ -40,7 +41,8 @@ export default ["esm", "cjs", "umd"].map(format => ({
             mangle: {
               toplevel: true
             }
-          })
+          }),
+          ...(format === "esm" ? [exportInPlace()] : [])
         ]),
     sizePrinter()
   ]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,7 +26,11 @@ export default ["esm", "cjs", "umd"].map(format => ({
     esModule: false
   },
   plugins: [
-    indexGenerator({ indexPath: "./src/index.js", pluginFolder: "detectors" }),
+    indexGenerator({
+      indexPath: "./src/index.js",
+      pluginFolder: "detectors",
+      format
+    }),
     ...(process.env.NO_MINIFY
       ? []
       : [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,7 +21,9 @@ export default ["esm", "cjs", "umd"].map(format => ({
   output: {
     dir: `dist/${format}`,
     format,
-    name: "wasmFeatureDetect"
+    name: "wasmFeatureDetect",
+    preferConst: true,
+    esModule: false
   },
   plugins: [
     indexGenerator({ indexPath: "./src/index.js", pluginFolder: "detectors" }),

--- a/src/detectors/big-int/index.js
+++ b/src/detectors/big-int/index.js
@@ -14,12 +14,11 @@
 export default async moduleBytes => {
   try {
     // This will throw a ReferenceError on platforms where BigInt is not
-    // supported. Please do not change the right hand side value to BigInt
+    // supported. Please do not change the test value to BigInt
     // literal (i.e. 0n), cause in that case a SyntaxError will be thrown
     // before an execution.
-    const n = BigInt(0);
     const instance = await WebAssembly.instantiate(moduleBytes);
-    return instance.instance.exports.b(n) === n;
+    return instance.instance.exports.b(BigInt(0)) === BigInt(0);
   } catch (e) {
     return false;
   }

--- a/src/detectors/threads/index.js
+++ b/src/detectors/threads/index.js
@@ -12,12 +12,11 @@
  */
 
 export default async moduleBytes => {
-  if (!WebAssembly.validate(moduleBytes)) return false;
   try {
     // Test for transferability of SABs (needed for Firefox)
     // https://groups.google.com/forum/#!msg/mozilla.dev.platform/IHkBZlHETpA/dwsMNchWEQAJ
     new MessageChannel().port1.postMessage(new SharedArrayBuffer(1));
-    return true;
+    return WebAssembly.validate(moduleBytes);
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
Improved bundle sizes using a range of techniques (each optimisation is described in a separate commit).

There are few more potential optimisations, but they provide less drastic results.

Gzipped sizes:
ESM: 564 -> 511 (-9%)
CJS: 617 -> 530 (-15%)
UMD: 676 -> 617 (-9%)