### PR TITLE
Switch to wabt.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ The _other_ reason is that you _should_ be using `WebAssembly.compile`, `WebAsse
 
 ## Contributing
 
-If you want to contribute a new feature test, all you need to do is create a new folder in `src/detectors` and it will be automatically picked up. The folder must contain a `module.wat` file, which will be compiled using [`wat2wasm`][wat2wasm].
+If you want to contribute a new feature test, all you need to do is create a new folder in `src/detectors` and it will be automatically picked up. The folder must contain a `module.wat` file, which will be compiled using [`wabt.js`](https://github.com/AssemblyScript/wabt.js).
 
 ```wat
 ;; Name: <Name of the feature for the README>
 ;; Proposal: <Link to the proposal’s explainer/repo>
-;; Flags: <CLI flags for `wat2wasm`>
+;; Features: <Space-separated list of WasmFeatures from wabt.js>
 
 (module
   ;; More WAT code here

--- a/package-lock.json
+++ b/package-lock.json
@@ -302,6 +302,12 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
+    },
+    "wabt": {
+      "version": "1.0.13-nightly.20200430",
+      "resolved": "https://registry.npmjs.org/wabt/-/wabt-1.0.13-nightly.20200430.tgz",
+      "integrity": "sha512-UP5GBb8k13w6vrIYv1y5ztOUzsiWUjysjFkJR6bQ6yaP3EJcS63Dss2a/zLRoYddECOJRMtErwrw8TyS8gcapA==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "markdown-it": "^10.0.0",
     "prettier": "^1.18.2",
     "rollup": "^1.20.3",
-    "rollup-plugin-terser": "^5.1.1"
+    "rollup-plugin-terser": "^5.1.1",
+    "wabt": "^1.0.13-nightly.20200430"
   }
 }

--- a/rollup-plugins/index-generator.js
+++ b/rollup-plugins/index-generator.js
@@ -37,14 +37,14 @@ export default function({ indexPath, pluginFolder, format }) {
             `./src/${pluginFolder}/${plugin}/module.wat`,
             "utf8"
           );
-          const flags = (/;;\s*Flags:\s*(.+)$/im.exec(source) || [
+          const features = (/;;\s*Features:\s*(.+)$/im.exec(source) || [
             "",
             ""
           ])[1].split(" ");
           const moduleBytes = JSON.stringify([
             ...(await compileWat(
               `./src/${pluginFolder}/${plugin}/module.wat`,
-              flags
+              features
             ))
           ]);
           const pluginName = camelCaseify(plugin);

--- a/src/detectors/bulk-memory/module.wat
+++ b/src/detectors/bulk-memory/module.wat
@@ -1,6 +1,6 @@
 ;; Name: Bulk memory operations
 ;; Proposal: https://github.com/webassembly/bulk-memory-operations
-;; Flags: --enable-bulk-memory
+;; Features: bulk_memory
 
 (module
   (memory 1)

--- a/src/detectors/exceptions/module.wat
+++ b/src/detectors/exceptions/module.wat
@@ -1,6 +1,6 @@
 ;; Name: Exception handling
 ;; Proposal: https://github.com/WebAssembly/exception-handling
-;; Flags: --enable-exceptions
+;; Features: exceptions
 
 (module
   (func

--- a/src/detectors/multi-value/module.wat
+++ b/src/detectors/multi-value/module.wat
@@ -1,6 +1,6 @@
 ;; Name: Multi-value
 ;; Proposal: https://github.com/WebAssembly/multi-value
-;; Flags: --enable-multi-value
+;; Features: multi_value
 
 (module
   (func (result i32 i32)

--- a/src/detectors/reference-types/module.wat
+++ b/src/detectors/reference-types/module.wat
@@ -1,6 +1,6 @@
 ;; Name: Reference Types
 ;; Proposal: https://github.com/WebAssembly/reference-types
-;; Flags: --enable-reference-types
+;; Features: reference_types
 
 (module
   (func

--- a/src/detectors/saturated-float-to-int/module.wat
+++ b/src/detectors/saturated-float-to-int/module.wat
@@ -1,6 +1,6 @@
 ;; Name: Non-trapping float-to-int conversions
 ;; Proposal: https://github.com/WebAssembly/nontrapping-float-to-int-conversions
-;; Flags: --enable-saturating-float-to-int
+;; Features: sat_float_to_int
 
 (module
   (func

--- a/src/detectors/sign-extensions/module.wat
+++ b/src/detectors/sign-extensions/module.wat
@@ -1,6 +1,6 @@
 ;; Name: Sign-extension operators
 ;; Proposal: https://github.com/WebAssembly/sign-extension-ops
-;; Flags: --enable-sign-extension
+;; Features: sign_extension
 
 (module
   (func

--- a/src/detectors/simd/module.wat
+++ b/src/detectors/simd/module.wat
@@ -1,6 +1,6 @@
 ;; Name: Fixed-Width SIMD
 ;; Proposal: https://github.com/webassembly/simd
-;; Flags: --enable-simd
+;; Features: simd
 
 (module
   (func

--- a/src/detectors/tail-call/module.wat
+++ b/src/detectors/tail-call/module.wat
@@ -1,6 +1,6 @@
 ;; Name: Tail call
 ;; Proposal: https://github.com/webassembly/tail-call
-;; Flags: --enable-tail-call
+;; Features: tail_call
 
 (module
   (func

--- a/src/detectors/threads/module.wat
+++ b/src/detectors/threads/module.wat
@@ -1,6 +1,6 @@
 ;; Name: Threads
 ;; Proposal: https://github.com/webassembly/threads
-;; Flags: --enable-threads
+;; Features: threads
 
 (module
   (memory 1 1 shared)


### PR DESCRIPTION

It's somewhat easier to use from JavaScript, makes wabt a regular npm dependency, and, what's even more important, is more frequently updated than WABT pre-built binaries.

It's not yet updated to fix #22 for us, but should be on the next nightly build - feel free to either merge this now or keep open until it gets updated.