### PR TITLE
Update the Wabt version to the latest release

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 mkdir wabt
-curl -L https://github.com/WebAssembly/wabt/releases/download/1.0.12/wabt-1.0.12-linux.tar.gz | tar -xz -C ./wabt
+curl -L https://github.com/WebAssembly/wabt/releases/download/1.0.15/wabt-1.0.15-linux.tar.gz | tar -xz -C ./wabt
 
 export PATH=$(echo $PWD/wabt/wabt-*)/:$PATH
 


### PR DESCRIPTION
Roll forward the Wabt version to include the SIMD opcode renumbering changes as reflected in the tracking issue - https://github.com/WebAssembly/simd/issues/216.