### PR TITLE
Remove build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-mkdir wabt
-curl -L https://github.com/WebAssembly/wabt/releases/download/1.0.12/wabt-1.0.12-linux.tar.gz | tar -xz -C ./wabt
-
-export PATH=$(echo $PWD/wabt/wabt-*)/:$PATH
-
-npm run build:website

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "build:readme": "node --experimental-modules ./render-readme.mjs",
     "build": "npm run build:library && npm run build:readme && npm run fmt",
     "build:website": "npm run build && node genwebsite.js",
-    "build:website:netlify": "./build.sh",
     "fmt": "prettier --write ./{,{src,rollup-plugins}/**/}*.{mjs,js,md}",
     "fmt_test": "prettier --check ./{,{src,rollup-plugins}/**/}*.{mjs,js,md}",
     "test": "npm run fmt_test && npm run build && node --no-warnings test/index.js"


### PR DESCRIPTION

We use JavaScript version of WABT now, so we no longer need a Unix build script and a separate command.