### PR TITLE
Fix threads detection on nodejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "wasm-feature-detect",
   "version": "1.2.5",
   "description": "A small library to detect which features of WebAssembly are supported in your current browser.",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index-node.js",
+  "module": "dist/esm/index-node.js",
+  "browser": "dist/cjs/index.js",
+  "unpkg": "dist/cjs/index.js",
   "scripts": {
     "build:library": "rollup -c",
     "build:readme": "node --experimental-modules ./render-readme.mjs",

--- a/rollup-plugins/index-generator.js
+++ b/rollup-plugins/index-generator.js
@@ -16,7 +16,7 @@ import { dirname, join } from "path";
 
 import { compileWat, fileExists, camelCaseify } from "./helpers.mjs";
 
-export default function({ indexPath, pluginFolder, format }) {
+export default function({ indexPath, pluginFolder, format, env }) {
   const rootPluginPath = join(dirname(indexPath), pluginFolder);
   return {
     resolveId(id) {
@@ -48,10 +48,15 @@ export default function({ indexPath, pluginFolder, format }) {
             ))
           ]);
           const pluginName = camelCaseify(plugin);
-          if (await fileExists(`./src/${pluginFolder}/${plugin}/index.js`)) {
+          // Only threads has a separate implementation for browser and nodejs.
+          const fileName =
+            plugin == "threads"
+              ? `${pluginFolder}/${plugin}/index-${env}.js`
+              : `${pluginFolder}/${plugin}/index.js`;
+          if (await fileExists(`./src/${fileName}`)) {
             const importName = `${pluginName}_internal`;
             return {
-              import: `import ${importName} from "./${pluginFolder}/${plugin}/index.js";`,
+              import: `import ${importName} from "./${fileName}";`,
               exportName: pluginName,
               exportValue: `() => ${importName}(new Uint8Array(${moduleBytes}))`
             };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,33 +17,36 @@ import indexGenerator from "./rollup-plugins/index-generator.js";
 import sizePrinter from "./rollup-plugins/size-printer.js";
 import exportInPlace from "./rollup-plugins/export-in-place.js";
 
-export default ["esm", "cjs", "umd"].map(format => ({
-  input: "./src/index.js",
-  output: {
-    dir: `dist/${format}`,
-    format,
-    name: "wasmFeatureDetect",
-    preferConst: true,
-    esModule: false
-  },
-  plugins: [
-    indexGenerator({
-      indexPath: "./src/index.js",
-      pluginFolder: "detectors",
-      format
-    }),
-    ...(process.env.NO_MINIFY
-      ? []
-      : [
-          terser({
-            ecma: 8,
-            compress: true,
-            mangle: {
-              toplevel: true
-            }
-          }),
-          ...(format === "esm" ? [exportInPlace()] : [])
-        ]),
-    sizePrinter()
-  ]
-}));
+export default ["browser", "node"].flatMap(env =>
+  ["esm", "cjs", "umd"].map(format => ({
+    input: "./src/index.js",
+    output: {
+      file: `dist/${format}/index${env === "browser" ? "" : "-node"}.js`,
+      format,
+      name: "wasmFeatureDetect",
+      preferConst: true,
+      esModule: false
+    },
+    plugins: [
+      indexGenerator({
+        indexPath: "./src/index.js",
+        pluginFolder: "detectors",
+        format,
+        env
+      }),
+      ...(process.env.NO_MINIFY
+        ? []
+        : [
+            terser({
+              ecma: 8,
+              compress: true,
+              mangle: {
+                toplevel: true
+              }
+            }),
+            ...(format === "esm" ? [exportInPlace()] : [])
+          ]),
+      sizePrinter()
+    ]
+  }))
+);

--- a/src/detectors/threads/index-node.js
+++ b/src/detectors/threads/index-node.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MessageChannel } from "worker_threads";
+
+export default async moduleBytes => {
+  try {
+    // Test for transferability of SABs (needed for Firefox)
+    // https://groups.google.com/forum/#!msg/mozilla.dev.platform/IHkBZlHETpA/dwsMNchWEQAJ
+    new MessageChannel().port1.postMessage(new SharedArrayBuffer(1));
+    return WebAssembly.validate(moduleBytes);
+  } catch (e) {
+    return false;
+  }
+};


### PR DESCRIPTION
We have a separate file for threads detection on nodejs,
threads/index-node.js. That means all the detectors' index.js should
work on both browser and node.

We generate new files in dist for node env, suffixed with `-node`.
Update package.json to point to the correct files:

- main and module is used by nodejs, it points to `index-node.js`
- browser is used for browser, so points to the `index.js`
- unpkg is used by browser (at least in the examples in README) so point
to `index.js` too

The rollup config is now a nested generation:
- for each env (browser and node),
- for each format (esm, cjs, umd),
- generate files

However the dist folder is still only 1 level deep, indexed by the
format.