### PR TITLE
Improve threads test

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A small library to detect which features of WebAssembly are supported.
 - ✅ Runs in Node
 - ✅ Provided as an ES6 module, CommonJS and UMD module.
 - ✅ CSP compatible
-- ✅ Only ~570B gzipped
+- ✅ Only ~540B gzipped
 
 ## Installation
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,7 +26,6 @@ export default ["esm", "cjs", "umd"].map(format => ({
     preferConst: true,
     esModule: false
   },
-  external: ["worker_threads"],
   plugins: [
     indexGenerator({
       indexPath: "./src/index.js",

--- a/src/detectors/threads/index.js
+++ b/src/detectors/threads/index.js
@@ -13,13 +13,11 @@
 
 export default async moduleBytes => {
   try {
-    const MessageChannelConstructor =
-      typeof MessageChannel !== "undefined"
-        ? MessageChannel
-        : await import("worker_threads").then(m => m.MessageChannel);
-    // Test for transferability of SABs (needed for Firefox)
-    // https://groups.google.com/forum/#!msg/mozilla.dev.platform/IHkBZlHETpA/dwsMNchWEQAJ
-    new MessageChannelConstructor().port1.postMessage(new SharedArrayBuffer(1));
+    if (typeof MessageChannel !== "undefined") {
+      // Test for transferability of SABs (needed for Firefox)
+      // https://groups.google.com/forum/#!msg/mozilla.dev.platform/IHkBZlHETpA/dwsMNchWEQAJ
+      new MessageChannel().port1.postMessage(new SharedArrayBuffer(1));
+    }
     return WebAssembly.validate(moduleBytes);
   } catch (e) {
     return false;


### PR DESCRIPTION
Slightly better alternative to https://github.com/GoogleChromeLabs/wasm-feature-detect/issues/32:
 - ~30 bytes off
 - Doesn't confuse bundlers with a worker_threads import (which they either throw an error on, or try to shim otherwise).