### PR TITLE
Some prettier-related fixes

### DIFF
--- a/README.md.ejs
+++ b/README.md.ejs
@@ -18,13 +18,13 @@ npm install -g wasm-feature-detect
 
 ```html
 <script type="module">
-  import { simd } from "wasm-feature-detect";
+	import { simd } from "wasm-feature-detect";
 
-  if (await simd()) {
-    /* SIMD support */
-  } else {
-    /* No SIMD support */
-  }
+	if (await simd()) {
+		/* SIMD support */
+	} else {
+		/* No SIMD support */
+	}
 </script>
 ```
 
@@ -32,8 +32,8 @@ npm install -g wasm-feature-detect
 
 ```html
 <script type="module">
-  import { simd } from "https://unpkg.com/wasm-feature-detect?module";
-  // ...
+	import { simd } from "https://unpkg.com/wasm-feature-detect?module";
+	// ...
 </script>
 ```
 
@@ -42,9 +42,9 @@ If required, there’s also a UMD version
 ```html
 <script src="https://unpkg.com/wasm-feature-detect/dist/umd/index.js"></script>
 <script>
-  if (await wasmFeatureDetect.simd()) {
-    // ...
-  }
+	if (await wasmFeatureDetect.simd()) {
+	  // ...
+	}
 </script>
 ```
 
@@ -53,7 +53,7 @@ If required, there’s also a UMD version
 All detectors return a `Promise<bool>`.
 
 | Function | Proposal |
-| --- | --- |
+| -------- | -------- |
 <% for (let detector of detectors) { _%>
 | `<%= detector.func %>()` | [<%= detector.name %>](<%= detector.proposal %>) |
 <%_ } %>

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "build": "npm run build:library && npm run build:readme && npm run build:dts && npm run fmt",
     "build:website": "npm run build && node genwebsite.cjs",
     "prepublishOnly": "npm run build",
-    "fmt": "prettier --no-error-on-unmatched-pattern --write ./{,src,test,rollup-plugins}/*.{mjs,cjs,js,md}",
-    "fmt_test": "prettier --check --no-error-on-unmatched-pattern --write ./{,src,test,rollup-plugins}/*.{mjs,cjs,js,md}",
+    "fmt": "prettier --write ./{src,test,rollup-plugins}/*.{mjs,cjs,js,md} *.{mjs,cjs,js,md}",
+    "fmt_test": "prettier --check --no-error-on-unmatched-pattern --write ./{src,test,rollup-plugins}/*.{mjs,cjs,js,md} *.{mjs,cjs,js,md}",
     "test": "npm run fmt_test && npm run build && node --no-warnings test/index.cjs"
   },
   "repository": "GoogleChromeLabs/wasm-feature-detect",


### PR DESCRIPTION
I applied prettier to README.md.ejs, replacing tabs with spaces there.

Also, it seems that fastGlob has some limitation that prevents it from correctly handling the glob pattern, so that prettier is not applied to README.md or other files in the root directory of the package. I worked around this limitation by duplicating the list of file endings.