### PR TITLE
Add feature detection for Multiple Memories proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A small library to detect which features of WebAssembly are supported.
 - ✅ Tree-shakable (only bundle the detectors you use)
 - ✅ Provided as an ES6, CommonJS and UMD module.
 - ✅ CSP compatible
-- ✅ All detectors add up to only ~700B gzipped
+- ✅ All detectors add up to only ~740B gzipped
 
 ## Installation
 
@@ -61,6 +61,7 @@ All detectors return a `Promise<bool>`.
 | `gc()`                   | [Garbage Collection](https://github.com/WebAssembly/gc)                                                      |
 | `jspi()`                 | [JavaScript Promise Integration](https://github.com/WebAssembly/js-promise-integration)                      |
 | `memory64()`             | [Memory64](https://github.com/WebAssembly/memory64)                                                          |
+| `multiMemory()`          | [Multiple Memories](https://github.com/WebAssembly/multi-memory)                                             |
 | `multiValue()`           | [Multi-value](https://github.com/WebAssembly/multi-value)                                                    |
 | `mutableGlobals()`       | [Importable/Exportable mutable globals]()                                                                    |
 | `referenceTypes()`       | [Reference Types](https://github.com/WebAssembly/reference-types)                                            |

--- a/src/detectors/multi-memory/index.js
+++ b/src/detectors/multi-memory/index.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2023 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+;; Name: Multiple Memories
+;; Proposal: https://github.com/WebAssembly/multi-memory
+;; Features: multi-memory
+*/
+
+export default async () => {
+	try {
+		new WebAssembly.Module(
+			// prettier-ignore
+			new Uint8Array([
+				// magic number
+				0x00, 0x61, 0x73, 0x6d,
+				0x01, 0x00, 0x00, 0x00,
+				0x05, // memory section id
+				0x05, // section length
+				0x02, // 2 memories
+				0x00, 0x00, // 1st has no max, min of 0
+				0x00, 0x00, // 2nd has no max, min of 0
+			]),
+		);
+		return true;
+	} catch (e) {
+		return false;
+	}
+};


### PR DESCRIPTION
We try to instantiate a module that defines two memories. If multiple memories is implemented, this will succeed but otherwise it throws an error like
```
CompileError: the number of memories must be at most one
```