### PR TITLE
Fixed issues with typing reported by publint

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,14 @@
   "version": "1.6.0",
   "description": "A small library to detect which features of WebAssembly are supported in your current browser.",
   "exports": {
-    "import": "./dist/esm/index.js",
-    "require": "./dist/cjs/index.cjs"
+    "import": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/esm/index.js"
+    },
+    "require": {
+      "types": "./dist/index.d.cts",
+      "default": "./dist/cjs/index.cjs"
+    }
   },
   "types": "dist/index.d.ts",
   "type": "module",

--- a/render-dts.mjs
+++ b/render-dts.mjs
@@ -21,3 +21,10 @@ writeFileSync(
 		.map(({ name }) => `${name}: () => Promise<boolean>`)
 		.join(",\n")};`,
 );
+
+writeFileSync(
+	"./dist/index.d.cts",
+	`export const\n${plugins
+		.map(({ name }) => `${name}: () => Promise<boolean>`)
+		.join(",\n")};`,
+);


### PR DESCRIPTION
The type definitions weren't set up correctly, so caused problems with Typescript's "moduleResolution": "bundler" option, as reported by publint here: https://publint.dev/wasm-feature-detect

This PR resolves that. Thanks for this package, it's very useful.