### PR TITLE
Add Support for 3 More Proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A small library to detect which features of WebAssembly are supported.
 - ✅ Tree-shakable (only bundle the detectors you use)
 - ✅ Provided as an ES6, CommonJS and UMD module.
 - ✅ CSP compatible
-- ✅ All detectors add up to only ~730B gzipped
+- ✅ All detectors add up to only ~980B gzipped
 
 ## Installation
 
@@ -52,27 +52,30 @@ If required, there’s also a UMD version
 
 All detectors return a `Promise<bool>`.
 
-| Function                 | Proposal                                                                                                     |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| `bigInt()`               | [BigInt integration](https://github.com/WebAssembly/JS-BigInt-integration)                                   |
-| `bulkMemory()`           | [Bulk memory operations](https://github.com/webassembly/bulk-memory-operations)                              |
-| `exceptions()`           | [Exception handling](https://github.com/WebAssembly/exception-handling)                                      |
-| `extendedConst()`        | [Extented Const Expressesions](https://github.com/WebAssembly/extended-const)                                |
-| `gc()`                   | [Garbage Collection](https://github.com/WebAssembly/gc)                                                      |
-| `jspi()`                 | [JavaScript Promise Integration](https://github.com/WebAssembly/js-promise-integration)                      |
-| `memory64()`             | [Memory64](https://github.com/WebAssembly/memory64)                                                          |
-| `multiMemory()`          | [Multiple Memories](https://github.com/WebAssembly/multi-memory)                                             |
-| `multiValue()`           | [Multi-value](https://github.com/WebAssembly/multi-value)                                                    |
-| `mutableGlobals()`       | [Importable/Exportable mutable globals]()                                                                    |
-| `referenceTypes()`       | [Reference Types](https://github.com/WebAssembly/reference-types)                                            |
-| `relaxedSimd()`          | [Relaxed SIMD](https://github.com/webassembly/relaxed-simd)                                                  |
-| `saturatedFloatToInt()`  | [Non-trapping float-to-int conversions](https://github.com/WebAssembly/nontrapping-float-to-int-conversions) |
-| `signExtensions()`       | [Sign-extension operators](https://github.com/WebAssembly/sign-extension-ops)                                |
-| `simd()`                 | [Fixed-Width SIMD](https://github.com/webassembly/simd)                                                      |
-| `streamingCompilation()` | [Streaming Compilation](https://webassembly.github.io/spec/web-api/index.html#streaming-modules)             |
-| `tailCall()`             | [Tail call](https://github.com/webassembly/tail-call)                                                        |
-| `threads()`              | [Threads](https://github.com/webassembly/threads)                                                            |
-| `typeReflection()`       | [Type Reflection](https://github.com/WebAssembly/js-types)                                                   |
+| Function                    | Proposal                                                                                                     |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `bigInt()`                  | [BigInt integration](https://github.com/WebAssembly/JS-BigInt-integration)                                   |
+| `bulkMemory()`              | [Bulk memory operations](https://github.com/webassembly/bulk-memory-operations)                              |
+| `exceptions()`              | [Legacy Exception Handling](https://github.com/WebAssembly/exception-handling)                               |
+| `exceptionsFinal()`         | [Exception Handling with exnref](https://github.com/WebAssembly/exception-handling)                          |
+| `extendedConst()`           | [Extented Const Expressesions](https://github.com/WebAssembly/extended-const)                                |
+| `gc()`                      | [Garbage Collection](https://github.com/WebAssembly/gc)                                                      |
+| `jsStringBuiltins()`        | [JS String Builtins Proposal for WebAssembly](https://github.com/WebAssembly/js-string-builtins)             |
+| `jspi()`                    | [JavaScript Promise Integration](https://github.com/WebAssembly/js-promise-integration)                      |
+| `memory64()`                | [Memory64](https://github.com/WebAssembly/memory64)                                                          |
+| `multiMemory()`             | [Multiple Memories](https://github.com/WebAssembly/multi-memory)                                             |
+| `multiValue()`              | [Multi-value](https://github.com/WebAssembly/multi-value)                                                    |
+| `mutableGlobals()`          | [Importable/Exportable mutable globals]()                                                                    |
+| `referenceTypes()`          | [Reference Types](https://github.com/WebAssembly/reference-types)                                            |
+| `relaxedSimd()`             | [Relaxed SIMD](https://github.com/webassembly/relaxed-simd)                                                  |
+| `saturatedFloatToInt()`     | [Non-trapping float-to-int conversions](https://github.com/WebAssembly/nontrapping-float-to-int-conversions) |
+| `signExtensions()`          | [Sign-extension operators](https://github.com/WebAssembly/sign-extension-ops)                                |
+| `simd()`                    | [Fixed-Width SIMD](https://github.com/webassembly/simd)                                                      |
+| `streamingCompilation()`    | [Streaming Compilation](https://webassembly.github.io/spec/web-api/index.html#streaming-modules)             |
+| `tailCall()`                | [Tail call](https://github.com/webassembly/tail-call)                                                        |
+| `threads()`                 | [Threads](https://github.com/webassembly/threads)                                                            |
+| `typeReflection()`          | [Type Reflection](https://github.com/WebAssembly/js-types)                                                   |
+| `typedFunctionReferences()` | [Typed function references](https://github.com/WebAssembly/function-references)                              |
 
 ## Why are all the tests async?
 

--- a/src/detectors/exceptions-final/index.js
+++ b/src/detectors/exceptions-final/index.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2023 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+;; Name: Exception Handling with exnref
+;; Proposal: https://github.com/WebAssembly/exception-handling
+;; Features: exceptions
+*/
+
+export default async () => {
+	try {
+		await WebAssembly.Module(
+			Uint8Array.from(
+				atob("AGFzbQEAAAABBAFgAAADAgEAChABDgACaR9AAQMAAAsACxoL"),
+				(m) => m.codePointAt(0),
+			),
+		);
+		return true;
+	} catch (e) {
+		return false;
+	}
+};

--- a/src/detectors/exceptions/module.wat
+++ b/src/detectors/exceptions/module.wat
@@ -1,4 +1,4 @@
-;; Name: Exception handling
+;; Name: Legacy Exception Handling
 ;; Proposal: https://github.com/WebAssembly/exception-handling
 ;; Features: exceptions
 

--- a/src/detectors/js-string-builtins/index.js
+++ b/src/detectors/js-string-builtins/index.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2023 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+;; Name: JS String Builtins Proposal for WebAssembly
+;; Proposal: https://github.com/WebAssembly/js-string-builtins
+;; Features:
+*/
+
+export default async () => {
+	try {
+		await WebAssembly.instantiate(
+			Uint8Array.from(
+				atob("AGFzbQEAAAABBgFgAW8BfwIXAQ53YXNtOmpzLXN0cmluZwR0ZXN0AAA="),
+				(m) => m.codePointAt(0),
+			),
+			{},
+			{ builtins: ["js-string"] },
+		);
+		return true;
+	} catch (e) {
+		return false;
+	}
+};

--- a/src/detectors/typed-function-references/index.js
+++ b/src/detectors/typed-function-references/index.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2023 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+;; Name: Typed function references
+;; Proposal: https://github.com/WebAssembly/function-references
+;; Features: function-references
+*/
+
+export default async () => {
+	try {
+		new WebAssembly.Module(
+			Uint8Array.from(
+				atob(
+					"AGFzbQEAAAABEANgAX8Bf2ABZAABf2AAAX8DBAMBAAIJBQEDAAEBChwDCwBBCkEqIAAUAGoLBwAgAEEBagsGANIBEAAL",
+				),
+				(m) => m.codePointAt(0),
+			),
+		);
+		return true;
+	} catch (e) {
+		return false;
+	}
+};


### PR DESCRIPTION
- Adds Support for `Exception Handling with exnref`
- Adds Support for `JS String Builtins Proposal for WebAssembly`
- Adds Support for `Typed function references`
- Renames old exception handling to `Legacy Exception Handling`

All of these are done to match the latest https://webassembly.org/features/